### PR TITLE
About console out and code review

### DIFF
--- a/.github/workflows/windows-mingw.yml
+++ b/.github/workflows/windows-mingw.yml
@@ -30,12 +30,12 @@ jobs:
           ./tools/sed/sed.exe -i "s/QT_TOOLS_DIR=C:\/Qt\/Qt6.2.0\/Tools\/mingw810_32\/bin/QT_TOOLS_DIR=C:\/ProgramData\/Chocolatey\/lib\/mingw\/tools\/install\/mingw64\/bin/g" ./win_deploy.bat
           ./win_deploy.bat
 
-      # - name: Upload build asserts
-      #   uses: actions/upload-artifact@v3.1.1
-      #   with:
-      #     name: helloqt_windows
-      #     path: |
-      #       ./InnoSetup/helloqt_setup.exe
+      - name: Upload build asserts
+        uses: actions/upload-artifact@v3.1.1
+        with:
+          name: helloqt_windows
+          path: |
+            ./InnoSetup/helloqt_setup.exe
 
       - name: Run tests
         run: |

--- a/helloqt.pro
+++ b/helloqt.pro
@@ -6,6 +6,7 @@ greaterThan(QT_MAJOR_VERSION, 4): QT += widgets
 DEFINES += QT_DEPRECATED_WARNINGS
 DEFINES += APP_VERSION="\\\"V$${HELLOQT_VERSION}\\\""
 CONFIG += c++17
+CONFIG += console
 
 # You can make your code fail to compile if it uses deprecated APIs.
 # In order to do so, uncomment the following line.

--- a/main.cpp
+++ b/main.cpp
@@ -1,21 +1,23 @@
 #include "mainwindow.h"
-
+#include <iostream>
 #include <QApplication>
 
 const QString VERSION = APP_VERSION;
 
 int main(int argc, char *argv[])
 {
+    QApplication a(argc, argv);
+
     if (argc == 2)
     {
         if ((!strncmp(argv[1], "--version", 9)))
         {
             qInfo() << QString("helloqt ") << VERSION;
+            std::cout << "std:helloqt " << VERSION.toStdString() << "\n";
             return 0;
         }
     }
 
-    QApplication a(argc, argv);
     MainWindow w;
     w.show();
     return a.exec();


### PR DESCRIPTION
Hi @iminders:

你好👋，我收到了你的邮件，因此帮你Review了一下代码。

https://github.com/iminders/helloqt/blob/f99ed8a15fe8b5b5b8cbd138e4c8aee5da6b706e/main.cpp#L9-L18
这里你使用了qInfo输出，但这个接口上用来输出调试信息的，查阅[文档](https://doc.qt.io/qt-6/debug.html)可以看到`With Windows, if it is a console application, the text is sent to console; otherwise, it is sent to the debugger.`如果希望他能在windows上输出到cmdline中，需要配置`CONFIG += console`，并且经过我的测试，即使这样中github action中也无法输出到stdout中，但你下载工件后本机运行应该说能看到的。顺带一提我比较建议大多数的Qt接口均在`QApplication`之后使用。

关于你的应用程序不能正常打开的问题，我做了一些测试，由于我没有windows机器(是的，我并不是windows开发的程序员，甚至手边没有能用的设备😅)，我首先在我的mac上测试你的程序，很显然他工作的很好，之后，我在添加`CONFIG += console`后通过CI编译下载工件在UTM win11虚拟中运行，我得到了如下错误提示：
```
QtMultimedia is not currently supported on this platform or compiler.

[已退出进程，代码为 3221227010 (0xc0000602)]
```
看起来使用aqtinstall安装的Qt6.2 mingw版本似乎QtMultimedia不能正常工作，又或许是我的UTM虚拟机的问题，这点暂时无法帮你排查。我还有个开源项目[game_box](https://github.com/QQxiaoming/game_box)，同样使用了multimedia模块用于音频工作，它工作的很好，也许你可以参考。

最后，如果你希望一个更加良好的cmdline命令解析，而不是简单的用stdout输出，我推荐使用Qt自带的QCommandLineParser库，可以很好的满足跨平台的需求，我在[这个项目](https://github.com/QQxiaoming/quard_star_tutorial/blob/main/quard_star_tools/main.cpp)里使用封装里它，可以参考。